### PR TITLE
Update install instructions in readme

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -35,7 +35,12 @@ You can install the development version from [GitHub](https://github.com/) with:
 
 ``` r
 # install.packages("devtools")
+# for versions of devtools earlier than 2.5.0 use `install_github()`
 devtools::install_github("humaniverse/geographr")
+
+# If you have devtools version 2.5.0 or greater use `pak`
+pak::pak("humaniverse/geographr")
+
 ```
 
 ## Development


### PR DESCRIPTION
Addresses installation error with v2.5.0 of devtools: 
```
Warning message:
`install_github()` was deprecated in devtools 2.5.0.
ℹ Please use pak::pak("user/repo") instead.
```